### PR TITLE
Update Test::Differences for Test::Builder 1.5

### DIFF
--- a/t/undef.t
+++ b/t/undef.t
@@ -17,6 +17,14 @@ TODO: {
 }
 
 my $builder = Test::More->builder;
-eq_or_diff [ map { $_->{actual_ok} } $builder->details ], [ map { 0 } $builder->details ],
-  "All TODO tests failed";
-
+# The Test::Builder 1.5 way to do it
+if ( $builder->can('history') ) {
+    is $builder->history->pass_count - $builder->history->todo_count,
+       $builder->history->literal_pass_count,
+       "All TODO tests failed";
+}
+# The Test::Builder 0.x way to do it
+else {
+    eq_or_diff [ map { $_->{actual_ok} } $builder->details ], [ map { 0 } $builder->details ],
+      "All TODO tests failed";
+}


### PR DESCRIPTION
This fixes Test::Differences for Test::Builder 1.5 (It still works with 0.98).

As results are no longer stored by default to save memory, use the test summary
statistics if they are available to track the failed TODO tests.
