### PR TITLE
make 'Got' and 'Expected' column headers configurable

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -5,13 +5,14 @@ use Module::Build;
 my $builder = Module::Build->new(
     module_name       => 'Test::Differences',
     license           => 'perl',
-    dist_author       => 'Curtis "Ovid" Poe <ovid@cpan.org>',
+    dist_author       => 'David Cantrell <david@cantrell.org.uk',
     dist_version_from => 'lib/Test/Differences.pm',
     perl              => 5.006,
     requires          => {
-        'Test::More'   => 0,
-        'Text::Diff'   => 0.35,
-        'Data::Dumper' => 2.126,
+        'Test::More'    => 0,
+        'Text::Diff'    => 0.35,
+        'Data::Dumper'  => 2.126,
+        'Capture::Tiny' => 0.24,
     },
     add_to_cleanup => ['Test-Differences-*'],
     meta_merge     => {

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Changes file for Test::Differences
 
 0.62
     - Document the Text::Diff unicode fix.
+    - Add ability to customise 'Got' and 'Expected' column headers
 
 0.61 Sat April 16, 2011
     - Allow an option to override Sortkeys in C<eq_or_diff>. Thanks to Mark

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,3 +18,6 @@ t/pod-coverage.t
 t/pod.t
 t/regression.t
 META.yml                                 Module meta-data (added by MakeMaker)
+t/column-headers.t
+t/script/custom-headers
+t/script/default-headers

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,14 +10,15 @@ if ( my $error = $@ ) {
 
 WriteMakefile(
     NAME          => 'Test::Differences',
-    AUTHOR        => 'Curtis "Ovid" Poe <ovid@cpan.org>',
+    AUTHOR        => 'David Cantrell <david@cantrell.org.uk>',
     VERSION_FROM  => 'lib/Test/Differences.pm',
     ABSTRACT_FROM => 'lib/Test/Differences.pm',
     PL_FILES      => {},
     PREREQ_PM     => {
-        'Test::More'   => 0,
-        'Text::Diff'   => 0.35,
-        'Data::Dumper' => 2.126,
+        'Test::More'    => 0,
+        'Text::Diff'    => 0.35,
+        'Data::Dumper'  => 2.126,
+        'Capture::Tiny' => 0.24,
     },
     dist       => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean      => { FILES    => 'Test-Differences-*' },

--- a/lib/Test/Differences.pm
+++ b/lib/Test/Differences.pm
@@ -709,13 +709,13 @@ Yves Orton <demerphq@hotmail.com>.  The plan to address this is to allow
 you to select Data::Denter or some other module of your choice as an
 option.
 
-=head1 AUTHOR
+=head1 AUTHORS
 
-    Barrie Slaymaker <barries@slaysys.com>
-
-=head1 MAINTAINER
+    Barrie Slaymaker <barries@slaysys.com> - original author
 
     Curtis "Ovid" Poe <ovid@cpan.org>
+
+    David Cantrell <david@cantrell.org.uk>
 
 =head1 LICENSE
 

--- a/t/column-headers.t
+++ b/t/column-headers.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Config;
+use Capture::Tiny qw(capture);
+
+END { done_testing(); }
+
+my($stdout, $stderr) = capture { system (
+    $Config{perlpath}, (map { "-I$_" } (@INC)),
+    't/script/default-headers'
+) };
+
+is(
+    $stderr,
+"
+#   Failed test 'both the same'
+#   at t/script/default-headers line 8.
+# +----+-------+----------+
+# | Elt|Got    |Expected  |
+# +----+-------+----------+
+# |   0|'foo'  |'foo'     |
+# *   1|'bar'  |'baz'     *
+# +----+-------+----------+
+# Looks like you failed 1 test of 1.
+",
+    "got expected error output"
+);
+
+($stdout, $stderr) = capture { system (
+    $Config{perlpath}, (map { "-I$_" } (@INC)),
+    't/script/custom-headers'
+) };
+
+is(
+    $stderr,
+"
+#   Failed test 'both the same'
+#   at t/script/custom-headers line 8.
+# +----+-------+-------+
+# | Elt|Lard   |Chips  |
+# +----+-------+-------+
+# |   0|'foo'  |'foo'  |
+# *   1|'bar'  |'baz'  *
+# +----+-------+-------+
+# Looks like you failed 1 test of 1.
+",
+    "got expected error output"
+);
+

--- a/t/script/custom-headers
+++ b/t/script/custom-headers
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Differences;
+END { done_testing(); }
+
+eq_or_diff(
+    { foo => 'bar' },
+    { foo => 'baz' },
+    "both the same",
+    { filename_a => 'Lard', filename_b => 'Chips' }
+);

--- a/t/script/default-headers
+++ b/t/script/default-headers
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Differences;
+END { done_testing(); }
+
+eq_or_diff(
+    { foo => 'bar' },
+    { foo => 'baz' },
+    "both the same"
+);


### PR DESCRIPTION
I'm using eq_or_diff to compare the structure of two database tables in a test, which for Necessary Reasons need to be identical. Having column headers 'Got' and 'Expected' isn't very helpful because it's not
immediately obvious which is which - after all, I've got them both.

So I've monkey-patched to make them configurable.

Patch attached. Includes doco but no tests because I'm very very lazy. Sorry about that :-)
