### PR TITLE
Update meta resources

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,15 @@ WriteMakefile(
     dist       => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean      => { FILES    => 'Test-Differences-*' },
     META_MERGE => {
-        resources =>
-          { repository => 'https://github.com/Ovid/Test-Differences' }
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/Ovid/Test-Differences.git',
+                web  => 'https://github.com/Ovid/Test-Differences',
+            },
+            bugtracker => {
+                web => 'https://github.com/Ovid/Test-Differences/issues',
+            },
+        },
     },
 );


### PR DESCRIPTION
This provides the repository git and web URLs, and sets the bug tracker to use
to be GitHub issues - so if you'd rather issues be kept on RT, then don't merge
this - but if that's the case I'd recommend disabling the issues section for the
repo on GH.
