### PR TITLE
Made all tests roughly the same style

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,9 +1,11 @@
 #!perl -T
 
+use strict;
+use warnings;
 use Test::More tests => 1;
 
 BEGIN {
-	use_ok( 'Test::Differences' );
+    use_ok( 'Test::Differences' ) || BAIL_OUT("Can't load the module!");
 }
 
 diag( "Testing Test::Differences $Test::Differences::VERSION, Perl $], $^X" );

--- a/t/column-headers.t
+++ b/t/column-headers.t
@@ -1,3 +1,5 @@
+#!perl
+
 use strict;
 use warnings;
 
@@ -49,4 +51,3 @@ is(
 ",
     "got expected error output"
 );
-

--- a/t/diff_styles.t
+++ b/t/diff_styles.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 
 use strict;
 use warnings;

--- a/t/example.t
+++ b/t/example.t
@@ -1,4 +1,7 @@
+#!perl
+
 use strict;
+use warnings;
 my $x;
 
 my $demo = $ENV{DEMO};

--- a/t/pass.t
+++ b/t/pass.t
@@ -1,13 +1,17 @@
+#!perl
+
+use strict;
+use warnings;
 use Test::More;
 use Test::Differences;
 
 # use large enough data sets that this thing chooses context => 3 instead
 # of "full document context".
-my $a = ( "\n" x 30 ) . "a\n";
-my $b = ( "\n" x 30 ) . "b\n";
+my $x = ( "\n" x 30 ) . "x\n";
+my $y = ( "\n" x 30 ) . "y\n";
 
-my @tests = ( 
-    sub { eq_or_diff [ "a", "b" ], [ "a", "b" ] }, 
+my @tests = (
+    sub { eq_or_diff [ "x", "y" ], [ "x", "y" ] },
 );
 
 plan tests => scalar @tests;

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,3 +1,5 @@
+#!perl
+
 use strict;
 use warnings;
 use Test::More;

--- a/t/regression.t
+++ b/t/regression.t
@@ -1,7 +1,7 @@
-#!/usr/bin/perl -w
+#!perl
 
 use strict;
-
+use warnings;
 use Test::More;
 use Test::Differences;
 

--- a/t/struct.t
+++ b/t/struct.t
@@ -1,5 +1,8 @@
-use Test::More;
+#!perl
 
+use strict;
+use warnings;
+use Test::More;
 use Test::Differences;
 
 ## This mind-bender submitted by Yves Orton <demerphq@hotmail.com>

--- a/t/test.t
+++ b/t/test.t
@@ -1,5 +1,8 @@
-use Test::More;
+#!perl
 
+use strict;
+use warnings;
+use Test::More;
 use Test::Differences;
 
 my @tests = (

--- a/t/text_vs_data.t
+++ b/t/text_vs_data.t
@@ -1,15 +1,19 @@
+#!perl
+
+use strict;
+use warnings;
 use Test::More;
 use Test::Differences;
 
 # use large enough data sets that this thing chooses context => 3 instead
 # of "full document context".
-my $a = ( "\n" x 30 ) . "a\n";
-my $b = ( "\n" x 30 ) . "b\n";
+my $x = ( "\n" x 30 ) . "x\n";
+my $y = ( "\n" x 30 ) . "y\n";
 
 my @tests = (
-    sub { eq_or_diff $a,      $b },
-    sub { eq_or_diff_text $a, $b },
-    sub { eq_or_diff_data $a, $b },
+    sub { eq_or_diff $x,      $y },
+    sub { eq_or_diff_text $x, $y },
+    sub { eq_or_diff_data $x, $y },
 );
 
 plan tests => scalar @tests;

--- a/t/undef.t
+++ b/t/undef.t
@@ -1,3 +1,7 @@
+#!perl
+
+use strict;
+use warnings;
 use Test::More qw(no_plan);
 use Test::Differences;
 


### PR DESCRIPTION
Hi!  I was assigned your module in this month's [PR challenge](http://cpan-prc.org/2016/may.html).  While reviewing the module, nothing immediately jumped out at me that needed a fix. So, I had to go nitpicking (no- really, really nitpick-y).  The test files were all slightly different in their beginnings, so I looked through them and found what seemed to be the most common theme and updated them all accordingly.

Some test files had a shebang line, some didn't.  Some had strict and warnings, others didn't.  They all now mostly start with a consistent first few lines:

``` perl
#!perl

use strict;
use warnings;
```

Two not quite as nitpick-y as the first changes were also made:
- In `00-load.t` it seems beneficial to go ahead and `BAIL_OUT` if the `use_ok` fails
- And, in `test.t` and `text_vs_data.t`, use `$x` and `$y` rather than `$a` and `$b` as they are special.

Thanks,
Chase
